### PR TITLE
pipeline: clean workspace after run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,4 +10,9 @@ pipeline {
       }
     }
   }
+  post {
+    always {
+      cleanWs()
+    }
+  }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,8 @@ pass_env =
   SSH_AUTH_SOCK
   TERM
   TTY
+set_env =
+  ANSIBLE_HOME = {temp_dir}/ansible
+  ANSIBLE_ROLES_PATH = {temp_dir}/ansible/roles
+  ANSIBLE_COLLECTIONS_PATH = {temp_dir}/ansible/collections
 commands = molecule {posargs:test}


### PR DESCRIPTION
**why**
It colludes with other the other runs on the new Jenkins agent when they are ran successively
-> cleans workspace
-> sets role requirements in ephemeral folder